### PR TITLE
Optional plugin to encrypt the LoginGuard settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /installers/angie
 
 /plugins/**/**/*.xml
+/plugins/loginguard/encrypt/secretkey.php
 
 /release
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -63,6 +63,9 @@
 		<copy file="${phing.dir}/templates/plg_loginguard_email.xml" tofile="${dirs.plugins}/loginguard/email/email.xml" overwrite="true">
 			<filterchain refid="manifest-replace-tokens" />
 		</copy>
+		<copy file="${phing.dir}/templates/plg_loginguard_encrypt.xml" tofile="${dirs.plugins}/loginguard/encrypt/encrypt.xml" overwrite="true">
+			<filterchain refid="manifest-replace-tokens" />
+		</copy>
 		<copy file="${phing.dir}/templates/plg_loginguard_fixed.xml" tofile="${dirs.plugins}/loginguard/fixed/fixed.xml" overwrite="true">
 			<filterchain refid="manifest-replace-tokens" />
 		</copy>

--- a/build/templates/loginguard.xml
+++ b/build/templates/loginguard.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU/GPL v3 or any later version</license>
 
 	<description>Akeeba LoginGuard</description>

--- a/build/templates/pkg_loginguard.xml
+++ b/build/templates/pkg_loginguard.xml
@@ -13,7 +13,7 @@
     <packager>Akeeba Ltd</packager>
     <packagerurl>https://www.akeebabackup.com</packagerurl>
 
-    <copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
 
     <description>Akeeba LoginGuard installation package v.##VERSION##</description>

--- a/build/templates/pkg_loginguard.xml
+++ b/build/templates/pkg_loginguard.xml
@@ -28,6 +28,7 @@
 
         <!-- Plugins: loginguard -->
         <file type="plugin" group="loginguard" id="email">plg_loginguard_email.zip</file>
+        <file type="plugin" group="loginguard" id="encrypt">plg_loginguard_encrypt.zip</file>
         <file type="plugin" group="loginguard" id="fixed">plg_loginguard_fixed.zip</file>
         <file type="plugin" group="loginguard" id="pushbullet">plg_loginguard_pushbullet.zip</file>
         <file type="plugin" group="loginguard" id="smsapi">plg_loginguard_smsapi.zip</file>

--- a/build/templates/plg_loginguard_email.xml
+++ b/build/templates/plg_loginguard_email.xml
@@ -8,7 +8,7 @@
     <authorEmail>no-reply@akeebabackup.com</authorEmail>
     <authorUrl>https://www.akeebabackup.com</authorUrl>
 
-    <copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
 
     <description>PLG_LOGINGUARD_EMAIL_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_encrypt.xml
+++ b/build/templates/plg_loginguard_encrypt.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.4.0" type="plugin" group="loginguard" method="upgrade">
+    <name>PLG_LOGINGUARD_ENCRYPT</name>
+    <version>##VERSION##</version>
+    <creationDate>##DATE##</creationDate>
+
+    <author>Akeeba Ltd</author>
+    <authorEmail>no-reply@akeebabackup.com</authorEmail>
+    <authorUrl>https://www.akeebabackup.com</authorUrl>
+
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
+    <license>GNU GPL v3 or later</license>
+
+    <description>PLG_LOGINGUARD_ENCRYPT_DESCRIPTION</description>
+
+    <files>
+        <filename plugin="encrypt">encrupt.php</filename>
+    </files>
+
+    <languages folder="language">
+        <language tag="en-GB">en-GB/en-GB.plg_loginguard_encrypt.ini</language>
+        <language tag="en-GB">en-GB/en-GB.plg_loginguard_encrypt.sys.ini</language>
+    </languages>
+</extension>

--- a/build/templates/plg_loginguard_fixed.xml
+++ b/build/templates/plg_loginguard_fixed.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 
 	<description>PLG_LOGINGUARD_FIXED_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_pushbullet.xml
+++ b/build/templates/plg_loginguard_pushbullet.xml
@@ -8,7 +8,7 @@
     <authorEmail>no-reply@akeebabackup.com</authorEmail>
     <authorUrl>https://www.akeebabackup.com</authorUrl>
 
-    <copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
 
     <description>PLG_LOGINGUARD_PUSHBULLET_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_smsapi.xml
+++ b/build/templates/plg_loginguard_smsapi.xml
@@ -8,7 +8,7 @@
     <authorEmail>no-reply@akeebabackup.com</authorEmail>
     <authorUrl>https://www.akeebabackup.com</authorUrl>
 
-    <copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
 
     <description>PLG_LOGINGUARD_SMSAPI_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_totp.xml
+++ b/build/templates/plg_loginguard_totp.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 
 	<description>PLG_LOGINGUARD_TOTP_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_u2f.xml
+++ b/build/templates/plg_loginguard_u2f.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 
 	<description>PLG_LOGINGUARD_U2F_DESCRIPTION</description>

--- a/build/templates/plg_loginguard_yubikey.xml
+++ b/build/templates/plg_loginguard_yubikey.xml
@@ -8,7 +8,7 @@
     <authorEmail>no-reply@akeebabackup.com</authorEmail>
     <authorUrl>https://www.akeebabackup.com</authorUrl>
 
-    <copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
 
     <description>PLG_LOGINGUARD_YUBIKEY_DESCRIPTION</description>

--- a/build/templates/plg_system_loginguard.xml
+++ b/build/templates/plg_system_loginguard.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 
 	<description>PLG_SYSTEM_LOGINGUARD_DESCRIPTION</description>

--- a/build/templates/plg_user_loginguard.xml
+++ b/build/templates/plg_user_loginguard.xml
@@ -8,7 +8,7 @@
 	<authorEmail>no-reply@akeebabackup.com</authorEmail>
 	<authorUrl>https://www.akeebabackup.com</authorUrl>
 
-	<copyright>Copyright (c)2016-2017 Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2016-2018 Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 
 	<description>PLG_USER_LOGINGUARD_DESCRIPTION</description>

--- a/component/backend/Model/Convert.php
+++ b/component/backend/Model/Convert.php
@@ -196,6 +196,7 @@ class Convert extends Model
 		$db->setQuery($query)->execute();
 
 		// Insert the new record
+		$this->container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$object]);
 		$db->insertObject('#__loginguard_tfa', $object, 'id');
 	}
 
@@ -243,6 +244,7 @@ class Convert extends Model
 		$db->setQuery($query)->execute();
 
 		// Insert the new record
+		$this->container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$object]);
 		$db->insertObject('#__loginguard_tfa', $object, 'id');
 	}
 
@@ -291,6 +293,7 @@ class Convert extends Model
 		$db->setQuery($query)->execute();
 
 		// Insert the new record
+		$this->container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$object]);
 		$db->insertObject('#__loginguard_tfa', $object, 'id');
 	}
 

--- a/component/frontend/Controller/Method.php
+++ b/component/frontend/Controller/Method.php
@@ -327,6 +327,8 @@ class Method extends Controller
 
 			$url = JRoute::_($nonSefUrl, false);
 			$this->setRedirect($url, $e->getMessage(), 'error');
+
+			return;
 		}
 
 		$this->setRedirect($url);

--- a/component/frontend/Helper/Tfa.php
+++ b/component/frontend/Helper/Tfa.php
@@ -142,6 +142,8 @@ abstract class Tfa
 				$container                      = Container::getInstance('com_loginguard');
 				self::$recordsPerUser[$user_id] = array_map(function ($record) use ($container) {
 					$container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$record]);
+
+					return $record;
 				}, $records);
 			}
 			catch (Exception $e)

--- a/component/frontend/Helper/Tfa.php
+++ b/component/frontend/Helper/Tfa.php
@@ -138,7 +138,11 @@ abstract class Tfa
 
 			try
 			{
-				self::$recordsPerUser[$user_id] = $db->setQuery($query)->loadObjectList();
+				$records                        = $db->setQuery($query)->loadObjectList();
+				$container                      = Container::getInstance('com_loginguard');
+				self::$recordsPerUser[$user_id] = array_map(function ($record) use ($container) {
+					$container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$record]);
+				}, $records);
 			}
 			catch (Exception $e)
 			{

--- a/component/frontend/Helper/Tfa.php
+++ b/component/frontend/Helper/Tfa.php
@@ -129,19 +129,29 @@ abstract class Tfa
 	{
 		if (!isset(self::$recordsPerUser[$user_id]))
 		{
-			$db = self::getContainer()->db;
+			$db    = self::getContainer()->db;
 			$query = $db->getQuery(true)
-				->select('*')
-				->from($db->qn('#__loginguard_tfa'))
-				->where($db->qn('user_id') . ' = ' . $db->q($user_id))
-				->order($db->qn('method') . ' ASC');
+			            ->select('*')
+			            ->from($db->qn('#__loginguard_tfa'))
+			            ->where($db->qn('user_id') . ' = ' . $db->q($user_id))
+			            ->order($db->qn('method') . ' ASC')
+			;
 
 			try
 			{
-				$records                        = $db->setQuery($query)->loadObjectList();
+				$records = $db->setQuery($query)->loadObjectList();
 				$container                      = Container::getInstance('com_loginguard');
-				self::$recordsPerUser[$user_id] = array_map(function ($record) use ($container) {
-					$container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$record]);
+				$methodModel                    = $container->factory->model('Method')->tmpInstance();
+				self::$recordsPerUser[$user_id] = array_map(function ($record) use ($container, $methodModel) {
+					$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
+
+					if (isset($record->must_save) && ($record->must_save === 1))
+					{
+						unset($record->must_save);
+						$recordToSave = clone $record;
+						$container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$recordToSave]);
+						$container->db->updateObject('#__loginguard_tfa', $recordToSave, ['id']);
+					}
 
 					return $record;
 				}, $records);

--- a/component/frontend/Model/BackupCodes.php
+++ b/component/frontend/Model/BackupCodes.php
@@ -8,6 +8,7 @@
 namespace Akeeba\LoginGuard\Site\Model;
 
 use Exception;
+use FOF30\Container\Container;
 use FOF30\Model\Model;
 use JCrypt;
 use Joomla\CMS\User\User;
@@ -61,6 +62,13 @@ class BackupCodes extends Model
 		{
 			$record = $db->setQuery($query)->loadObject();
 			$this->getContainer()->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
+
+			if (isset($record->must_save) && ($record->must_save === 1))
+			{
+				/** @var Method $methodModel */
+				$methodModel = $this->getContainer()->factory->model('Method')->tmpInstance();
+				$methodModel->saveRecord($record);
+			}
 		}
 		catch (Exception $e)
 		{
@@ -109,6 +117,13 @@ class BackupCodes extends Model
 				$record = $db->setQuery($query)->loadObject();
 				$this->getContainer()->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
 				$json = $record->options;
+
+				if (isset($record->must_save) && ($record->must_save === 1))
+				{
+					/** @var Method $methodModel */
+					$methodModel = $this->getContainer()->factory->model('Method')->tmpInstance();
+					$methodModel->saveRecord($record);
+				}
 			}
 			catch (Exception $e)
 			{

--- a/component/frontend/Model/Captive.php
+++ b/component/frontend/Model/Captive.php
@@ -222,6 +222,7 @@ class Captive extends Model
 		try
 		{
 			$record = $db->setQuery($query)->loadObject();
+			$this->container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
 		}
 		catch (Exception $e)
 		{

--- a/component/frontend/Model/Captive.php
+++ b/component/frontend/Model/Captive.php
@@ -223,6 +223,13 @@ class Captive extends Model
 		{
 			$record = $db->setQuery($query)->loadObject();
 			$this->container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
+
+			if (isset($record->must_save) && ($record->must_save === 1))
+			{
+				/** @var Method $methodModel */
+				$methodModel = $this->getContainer()->factory->model('Method')->tmpInstance();
+				$methodModel->saveRecord($record);
+			}
 		}
 		catch (Exception $e)
 		{

--- a/component/frontend/Model/Method.php
+++ b/component/frontend/Model/Method.php
@@ -119,7 +119,7 @@ class Method extends Model
 		}
 
 		/**
-		 * Call onLoginGuardAfterReadRecord($user, &$record)
+		 * Call onLoginGuardAfterReadRecord(&$record)
 		 *
 		 * This event fires right after a record has been successfully read from the database. You have the chance to
 		 * modify the record. At this point we have not yet checked whether the record's method refers to an existing,

--- a/component/frontend/Model/Method.php
+++ b/component/frontend/Model/Method.php
@@ -98,15 +98,6 @@ class Method extends Model
 		$defaultRecord = $this->getDefaultRecord($user);
 		$id            = (int) $this->getState('id', 0);
 
-		/**
-		 * Call onLoginGuardBeforeReadRecord($user)
-		 *
-		 * This event is executed before we attempt to read the record from the database. This event is meant to be only
-		 * informative. You cannot modify any data. Moreover, it's not yet guaranteed that anything will be read off the
-		 * database just yet.
-		 */
-		$this->container->platform->runPlugins('onLoginGuardBeforeReadRecord', [$user, $id]);
-
 		if ($id <= 0)
 		{
 			return $defaultRecord;
@@ -134,7 +125,7 @@ class Method extends Model
 		 * modify the record. At this point we have not yet checked whether the record's method refers to an existing,
 		 * activated LoginGuard authentication method plugin.
 		 */
-		$this->container->platform->runPlugins('onLoginGuardAfterReadRecord', [$user, &$record]);
+		$this->container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$record]);
 
 		if (!$this->methodExists($record->method))
 		{
@@ -277,14 +268,6 @@ class Method extends Model
 		{
 			throw new RuntimeException($db->getErrorMsg());
 		}
-
-		/**
-		 * Call onLoginGuardAfterSaveRecord($record).
-		 *
-		 * You cannot modify the record any more. The purpose of this event is informative, e.g. if you need to sync the
-		 * TFA preferences with third party software / services. If you need to modify the record use the Before event.
-		 */
-		$this->container->platform->runPlugins('onLoginGuardAfterSaveRecord', [$record]);
 
 		// If that was the very first method we added for that user let's also create their backup codes
 		if ($isNewRecord && !count($records))

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -154,14 +154,13 @@ class PlgLoginguardEncrypt extends JPlugin
 	/**
 	 * Decrypt the LoginGuard configuration after reading it from the database.
 	 *
-	 * @param   JUser   $user    The user for which we are reading the LoginGuard record
 	 * @param   object  $record  The LoginGuard record we read from the database
 	 *
 	 * @return  void
 	 *
 	 * @since   2.0.2
 	 */
-	public function onLoginGuardAfterReadRecord($user, &$record)
+	public function onLoginGuardAfterReadRecord(&$record)
 	{
 		if (empty($this->password))
 		{
@@ -199,16 +198,16 @@ class PlgLoginguardEncrypt extends JPlugin
 
 		if (file_exists($keyFile))
 		{
-			include_once $keyFile;
+			@include_once $keyFile;
 		}
 
 		if (!defined('AKEEBA_LOGINGUARD_ENCRYPT_KEY'))
 		{
 			$this->generateKey($keyFile);
 
-			if (include_once($keyFile) === false)
+			if (file_exists($keyFile))
 			{
-				return '';
+				@include_once $keyFile;
 			}
 		}
 
@@ -233,7 +232,7 @@ class PlgLoginguardEncrypt extends JPlugin
 	{
 		$key = JUserHelper::genRandomPassword(32);
 
-		$fileData = '<?' . "php\ndefined('_JEXEC') or die;\n\n";
+		$fileData = '<?' . "php defined('_JEXEC') or die;\n";
 		$fileData .= "define('AKEEBA_LOGINGUARD_ENCRYPT_KEY', '$key');\n";
 
 		if (@file_put_contents($keyFile, $fileData) !== false)

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * @package   AkeebaLoginGuard
+ * @copyright Copyright (c)2016-2018 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 3, or later
+ */
+
+// Prevent direct access
+use FOF30\Input\Input;
+
+defined('_JEXEC') or die;
+
+// Minimum PHP version check
+if (!version_compare(PHP_VERSION, '5.4.0', '>='))
+{
+	return;
+}
+
+/**
+ * Work around the very broken and completely defunct eAccelerator on PHP 5.4 (or, worse, later versions).
+ */
+if (function_exists('eaccelerator_info'))
+{
+	$isBrokenCachingEnabled = true;
+
+	if (function_exists('ini_get') && !ini_get('eaccelerator.enable'))
+	{
+		$isBrokenCachingEnabled = false;
+	}
+
+	if ($isBrokenCachingEnabled)
+	{
+		/**
+		 * I know that this define seems pointless since I am returning. This means that we are exiting the file and
+		 * the plugin class isn't defined, so Joomla cannot possibly use it.
+		 *
+		 * Well, that is how PHP works. Unfortunately, eAccelerator has some "novel" ideas about how to go about it.
+		 * For very broken values of "novel". What does it do? It ignores the return and parses the plugin class below.
+		 *
+		 * You read that right. It ignores ALL THE CODE between here and the class declaration and parses the
+		 * class declaration. Therefore the only way to actually NOT load the  plugin when you are using it on a
+		 * server where an irresponsible sysadmin has installed and enabled eAccelerator (IT'S END OF LIFE AND BROKEN
+		 * PER ITS CREATORS FOR CRYING OUT LOUD) is to define a constant and use it to return from the constructor
+		 * method, therefore forcing PHP to return null instead of an object. This prompts Joomla to not do anything
+		 * with the plugin.
+		 */
+		if (!defined('AKEEBA_EACCELERATOR_IS_SO_BORKED_IT_DOES_NOT_EVEN_RETURN'))
+		{
+			define('AKEEBA_EACCELERATOR_IS_SO_BORKED_IT_DOES_NOT_EVEN_RETURN', 3245);
+		}
+
+		return;
+	}
+}
+
+// Make sure Akeeba LoginGuard is installed
+if (!file_exists(JPATH_ADMINISTRATOR . '/components/com_loginguard'))
+{
+	return;
+}
+
+// Load FOF
+if (!defined('FOF30_INCLUDED') && !@include_once(JPATH_LIBRARIES . '/fof30/include.php'))
+{
+	return;
+}
+
+/**
+ * Akeeba LoginGuard Plugin for encrypting the data at rest.
+ *
+ * This plugin intercepts the LoginGuard TFA records read and written to the database, applying cryptography to the
+ * "options" property which stores the configuration information for the authentication method. The encryption key is
+ * a randomly generated key, stored in the file secretkey.php inside the plugin's directory. If it cannot be created
+ * automatically you need to create it yourself with the following contents:
+ *
+ * <?php defined('_JEXEC') or die();
+ * define('AKEEBA_LOGINGUARD_ENCRYPT_KEY', 'YOUR_PASSWORD_HERE');
+ *
+ * where YOUR_PASSWORD_HERE is a long, random password. We recommend creating one with the random password generator at
+ * https://www.random.org/passwords/?num=1&len=24&format=html&rnd=new
+ *
+ * WARNING! Encrypting your LoginGuard configuration DOES NOT offer the same kind of protection as "encrypting" the
+ * login passwords. In fact, Joomla (and WordPress, Drupal, Magento etc) does not store passwords "encrypted", it stores
+ * them _hashed_. Hashing is highly asymmetrical: deriving the hash from a password takes milliseconds whereas deriving
+ * the password from a hash takes anywhere from hours to millions of years. Encryption is highly symmetrical: getting
+ * the encrypted version of unencrypted information _and_ getting the unencrypted information from its encrypted version
+ * takes milliseconds, in both cases. The use of reversible encryption in LoginGuard is stipulated by the kind of data
+ * being stored: we need the raw, unencrypted data as a _seed_ to generate a temporary, single-use authentication code
+ * be it a six digit time-based one time password or a cryptographic U2F signature. Passwords, on the other hand, are
+ * entirely different. Passwords are immutable _and_ are provided in the plain ("unencrypted") when the user logs in.
+ * This means that you can generate the hash of the password provided by the user in the login form, which takes mere
+ * milliseconds, and compare it with the hash stored in the database without having to reverse the hash at any point
+ * (which would take millions of years!). This is only possible because of the immutability of passwords. Long story
+ * cut short, if an attacker gets hold of *BOTH* your site's database *AND* its files they can very easily decrypt the
+ * LoginGuard information. This is a perfectly acceptable risk since LoginGuard is a second authentication step, meant
+ * to protect the user against their password being stolen somewhere outside of your server. Second authentication steps
+ * DO NOT protect against your server being already compromised. This largely makes the point of encrypting the
+ * LoginGuard configuration information rather moot which is why this plugin is disabled by default. The benefits of
+ * encrypting LoginGuard's configuration are confined to very limited use cases, e.g. the Joomla! login being used as
+ * a single sign on (SSO) method for a valuable asset and the Joomla! site's database (but NOT its files) may be read by
+ * untrusted agents. This is, of course, A MASSIVE OPERATIONAL SECURITY FAILURE. We DO NOT recommend using LoginGuard
+ * options encryption as your last line of defense in this kind of situations. Basically, if you find yourself in a
+ * situation where you _need_ to enable this plugin YOUR SITE HAS ALREADY BEEN "PWNED" (COMPROMISED) AND YOU ARE GOING
+ * TO REGRET YOUR BAD DECISIONS. We accept NO RESPONSIBILITY WHATSOEVER per the license of the software. YOU HAVE BEEN
+ * WARNED. Then why do we have this plugin? Bluntly put, because there are folks out there who don't understand
+ * operational security and insist that having LoginGuard not encrypt its configuration is a "security risk" when, in
+ * fact, the security risk comes from the reckless disregard of operational security managing the site. This plugin is,
+ * therefore, little more than a placebo for these folks.
+ */
+class PlgLoginguardEncrypt extends JPlugin
+{
+	/**
+	 * Caches the password used by this plugin to encrypt the LoginGuard information.
+	 *
+	 * @var  string
+	 */
+	private $password = '';
+
+	public function __construct($subject, array $config = array())
+	{
+		parent::__construct($subject, $config);
+
+		$this->password = $this->getSecretKey();
+	}
+
+
+	/**
+	 * Encrypt the LoginGuard configuration before saving it to the database.
+	 *
+	 * @param   object $record The record being saved
+	 *
+	 * @return  void
+	 *
+	 * @throws  Exception
+	 *
+	 * @since   2.0.2
+	 */
+	public function onLoginGuardBeforeSaveRecord(&$record)
+	{
+		if (empty($this->password))
+		{
+			JFactory::getApplication()->enqueueMessage(JText::_('PLG_LOGINGUARD_ENCRYPT_ERR_CANTSAVEPASSWORD'), 'error');
+
+			return;
+		}
+
+		// TODO Remove me
+		return;
+
+		$aes = new FOF30\Encrypt\Aes($this->password, 128, 'cbc');
+		$record->options = '###AES128###' . $aes->encryptString($record->options);
+	}
+
+	/**
+	 * Decrypt the LoginGuard configuration after reading it from the database.
+	 *
+	 * @param   JUser   $user    The user for which we are reading the LoginGuard record
+	 * @param   object  $record  The LoginGuard record we read from the database
+	 *
+	 * @return  void
+	 *
+	 * @since   2.0.2
+	 */
+	public function onLoginGuardAfterReadRecord($user, &$record)
+	{
+		if (empty($this->password))
+		{
+			return;
+		}
+
+		// TODO Remove me
+		return;
+
+		if (substr($record->options, 0, 12) != '###AES128###')
+		{
+			// The settings are not encrypted yet. Flag them as in need to be saved again.
+			$record->must_save = 1;
+
+			return;
+		}
+
+		$aes = new FOF30\Encrypt\Aes($this->password, 128, 'cbc');
+		$encrypted = substr($record->options, 12);
+		$record->options = $aes->decryptString($encrypted);
+	}
+
+	/**
+	 * Gets the secret key for settings encryption. If none exists yet, it will be generated for you.
+	 *
+	 * @return  string
+	 *
+	 * @return  void
+	 *
+	 * @since   2.0.2
+	 */
+	private function getSecretKey()
+	{
+		$keyFile = __DIR__ . '/secretkey.php';
+
+		if (file_exists($keyFile))
+		{
+			include_once $keyFile;
+		}
+
+		if (!defined('AKEEBA_LOGINGUARD_ENCRYPT_KEY'))
+		{
+			$this->generateKey($keyFile);
+
+			if (include_once($keyFile) === false)
+			{
+				return '';
+			}
+		}
+
+		if (!defined('AKEEBA_LOGINGUARD_ENCRYPT_KEY'))
+		{
+			return '';
+		}
+
+		return AKEEBA_LOGINGUARD_ENCRYPT_KEY;
+	}
+
+	/**
+	 * Generates a secret key file with a new, random key.
+	 *
+	 * @param   string  $keyFile  The path to the file where the key will be saved
+	 *
+	 * @return  void
+	 *
+	 * @since   2.0.2
+	 */
+	private function generateKey($keyFile)
+	{
+		$key = JUserHelper::genRandomPassword(32);
+
+		$fileData = '<?' . "php\ndefined('_JEXEC') or die;\n\n";
+		$fileData .= "define('AKEEBA_LOGINGUARD_ENCRYPT_KEY', '$key');\n";
+
+		if (@file_put_contents($keyFile, $fileData) !== false)
+		{
+			return;
+		}
+
+		JFile::write($keyFile, $fileData);
+	}
+}

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -174,7 +174,7 @@ class PlgLoginguardEncrypt extends JPlugin
 
 		$aes = new FOF30\Encrypt\Aes($this->password, 128, 'cbc');
 		$encrypted = substr($record->options, 12);
-		$record->options = $aes->decryptString($encrypted);
+		$record->options = rtrim($aes->decryptString($encrypted));
 	}
 
 	/**

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -144,7 +144,6 @@ class PlgLoginguardEncrypt extends JPlugin
 			return;
 		}
 
-		// TODO Remove me
 		return;
 
 		$aes = new FOF30\Encrypt\Aes($this->password, 128, 'cbc');
@@ -166,9 +165,6 @@ class PlgLoginguardEncrypt extends JPlugin
 		{
 			return;
 		}
-
-		// TODO Remove me
-		return;
 
 		if (substr($record->options, 0, 12) != '###AES128###')
 		{

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -144,8 +144,6 @@ class PlgLoginguardEncrypt extends JPlugin
 			return;
 		}
 
-		return;
-
 		$aes = new FOF30\Encrypt\Aes($this->password, 128, 'cbc');
 		$record->options = '###AES128###' . $aes->encryptString($record->options);
 	}

--- a/plugins/loginguard/encrypt/encrypt.php
+++ b/plugins/loginguard/encrypt/encrypt.php
@@ -68,44 +68,7 @@ if (!defined('FOF30_INCLUDED') && !@include_once(JPATH_LIBRARIES . '/fof30/inclu
 /**
  * Akeeba LoginGuard Plugin for encrypting the data at rest.
  *
- * This plugin intercepts the LoginGuard TFA records read and written to the database, applying cryptography to the
- * "options" property which stores the configuration information for the authentication method. The encryption key is
- * a randomly generated key, stored in the file secretkey.php inside the plugin's directory. If it cannot be created
- * automatically you need to create it yourself with the following contents:
- *
- * <?php defined('_JEXEC') or die();
- * define('AKEEBA_LOGINGUARD_ENCRYPT_KEY', 'YOUR_PASSWORD_HERE');
- *
- * where YOUR_PASSWORD_HERE is a long, random password. We recommend creating one with the random password generator at
- * https://www.random.org/passwords/?num=1&len=24&format=html&rnd=new
- *
- * WARNING! Encrypting your LoginGuard configuration DOES NOT offer the same kind of protection as "encrypting" the
- * login passwords. In fact, Joomla (and WordPress, Drupal, Magento etc) does not store passwords "encrypted", it stores
- * them _hashed_. Hashing is highly asymmetrical: deriving the hash from a password takes milliseconds whereas deriving
- * the password from a hash takes anywhere from hours to millions of years. Encryption is highly symmetrical: getting
- * the encrypted version of unencrypted information _and_ getting the unencrypted information from its encrypted version
- * takes milliseconds, in both cases. The use of reversible encryption in LoginGuard is stipulated by the kind of data
- * being stored: we need the raw, unencrypted data as a _seed_ to generate a temporary, single-use authentication code
- * be it a six digit time-based one time password or a cryptographic U2F signature. Passwords, on the other hand, are
- * entirely different. Passwords are immutable _and_ are provided in the plain ("unencrypted") when the user logs in.
- * This means that you can generate the hash of the password provided by the user in the login form, which takes mere
- * milliseconds, and compare it with the hash stored in the database without having to reverse the hash at any point
- * (which would take millions of years!). This is only possible because of the immutability of passwords. Long story
- * cut short, if an attacker gets hold of *BOTH* your site's database *AND* its files they can very easily decrypt the
- * LoginGuard information. This is a perfectly acceptable risk since LoginGuard is a second authentication step, meant
- * to protect the user against their password being stolen somewhere outside of your server. Second authentication steps
- * DO NOT protect against your server being already compromised. This largely makes the point of encrypting the
- * LoginGuard configuration information rather moot which is why this plugin is disabled by default. The benefits of
- * encrypting LoginGuard's configuration are confined to very limited use cases, e.g. the Joomla! login being used as
- * a single sign on (SSO) method for a valuable asset and the Joomla! site's database (but NOT its files) may be read by
- * untrusted agents. This is, of course, A MASSIVE OPERATIONAL SECURITY FAILURE. We DO NOT recommend using LoginGuard
- * options encryption as your last line of defense in this kind of situations. Basically, if you find yourself in a
- * situation where you _need_ to enable this plugin YOUR SITE HAS ALREADY BEEN "PWNED" (COMPROMISED) AND YOU ARE GOING
- * TO REGRET YOUR BAD DECISIONS. We accept NO RESPONSIBILITY WHATSOEVER per the license of the software. YOU HAVE BEEN
- * WARNED. Then why do we have this plugin? Bluntly put, because there are folks out there who don't understand
- * operational security and insist that having LoginGuard not encrypt its configuration is a "security risk" when, in
- * fact, the security risk comes from the reckless disregard of operational security managing the site. This plugin is,
- * therefore, little more than a placebo for these folks.
+ * This plugin is not necessary on most sites. Enabling it has non-obvious downsides. READ THE DOCUMENTATION FIRST.
  */
 class PlgLoginguardEncrypt extends JPlugin
 {

--- a/plugins/loginguard/encrypt/language/index.html
+++ b/plugins/loginguard/encrypt/language/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title></title></head><body></body></html>

--- a/plugins/loginguard/u2f/u2f.php
+++ b/plugins/loginguard/u2f/u2f.php
@@ -832,6 +832,13 @@ JS;
 		{
 			$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$result]);
 
+			if (isset($result->must_save) && ($result->must_save === 1))
+			{
+				/** @var \Akeeba\LoginGuard\Site\Model\Method $methodModel */
+				$methodModel = $container->factory->model('Method')->tmpInstance();
+				$methodModel->saveRecord($record);
+			}
+
 			$options = $this->_decodeRecordOptions($result);
 
 			if (!isset($options['registrations']) || empty($options['registrations']))
@@ -886,6 +893,14 @@ JS;
 		foreach ($records as $aRecord)
 		{
 			$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$aRecord]);
+
+			if (isset($aRecord->must_save) && ($aRecord->must_save === 1))
+			{
+				/** @var \Akeeba\LoginGuard\Site\Model\Method $methodModel */
+				$methodModel = $container->factory->model('Method')->tmpInstance();
+				$methodModel->saveRecord($aRecord);
+			}
+
 			$recordOptions       = $this->_decodeRecordOptions($aRecord);
 			$recordRegistrations = isset($recordOptions['registrations']) ? $recordOptions['registrations'] : array();
 			$registrations       = array_merge($registrations, $recordRegistrations);

--- a/plugins/loginguard/u2f/u2f.php
+++ b/plugins/loginguard/u2f/u2f.php
@@ -681,6 +681,9 @@ JS;
 			'options' => json_encode(array('registrations' => array($registration)))
 		);
 
+		$container = Container::getInstance('com_loginguard');
+		$container->platform->runPlugins('onLoginGuardBeforeSaveRecord', [&$update]);
+
 		$db = JFactory::getDbo();
 		$db->updateObject('#__loginguard_tfa', $update, array('id'));
 
@@ -823,8 +826,12 @@ JS;
 			return $return;
 		}
 
+		$container = Container::getInstance('com_loginguard');
+
 		foreach ($results as $result)
 		{
+			$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$result]);
+
 			$options = $this->_decodeRecordOptions($result);
 
 			if (!isset($options['registrations']) || empty($options['registrations']))
@@ -874,8 +881,11 @@ JS;
 		}
 
 		// Loop all records, stop if at least one matches
+		$container = Container::getInstance('com_loginguard');
+
 		foreach ($records as $aRecord)
 		{
+			$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$aRecord]);
 			$recordOptions       = $this->_decodeRecordOptions($aRecord);
 			$recordRegistrations = isset($recordOptions['registrations']) ? $recordOptions['registrations'] : array();
 			$registrations       = array_merge($registrations, $recordRegistrations);

--- a/plugins/loginguard/yubikey/yubikey.php
+++ b/plugins/loginguard/yubikey/yubikey.php
@@ -335,6 +335,13 @@ class PlgLoginguardYubikey extends JPlugin
 			{
 				$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$aRecord]);
 
+				if (isset($aRecord->must_save) && ($aRecord->must_save === 1))
+				{
+					/** @var \Akeeba\LoginGuard\Site\Model\Method $methodModel */
+					$methodModel = $container->factory->model('Method')->tmpInstance();
+					$methodModel->saveRecord($aRecord);
+				}
+
 				if ($this->validateAgainstRecord($aRecord, $code))
 				{
 					return true;

--- a/plugins/loginguard/yubikey/yubikey.php
+++ b/plugins/loginguard/yubikey/yubikey.php
@@ -329,8 +329,12 @@ class PlgLoginguardYubikey extends JPlugin
 			}
 
 			// Loop all records, stop if at least one matches
+			$container = \FOF30\Container\Container::getInstance('com_loginguard');
+
 			foreach ($records as $aRecord)
 			{
+				$container->platform->runPlugins('onLoginGuardAfterReadRecord', [&$aRecord]);
+
 				if ($this->validateAgainstRecord($aRecord, $code))
 				{
 					return true;
@@ -627,7 +631,7 @@ class PlgLoginguardYubikey extends JPlugin
 	 */
 	private function validateAgainstRecord($record, $code)
 	{
-// Load the options from the record (if any)
+		// Load the options from the record (if any)
 		$options = $this->_decodeRecordOptions($record);
 		$keyID   = isset($options['id']) ? $options['id'] : '';
 


### PR DESCRIPTION
### Summary of Changes

An optional plugin to encrypt the `options` column of the `#__loginguard_tfa` table. This provides encryption of the data at rest. There are caveats. RTFM.

### Backwards compatibility

If you do not enable the plugin (default) nothing changes.

If you enable the plugin, all reads and writes to the `#__loginguard_tfa` table must use the new plugin events which allow data encryption and decryption. Failure to do so will result in certain 2SV plugins doing direct table queries to fail.

Enabling the plugin encrypts the data. Disabling the plugin does NOT decrypt the data.

Therefore this plugin _is not_ backwards compatible.

### Documentation Changes Required

New documentation page required.

### Translation impact

Added translation files. No existing language strings are modified.

### Technical information

The encryption uses Rijndael-128 (same as AES-128) in CBC mode with a PBKDF2 key expansion. Availability of encryption depends upon the PHP OpenSSL or mcrypt module being available as well as the relevant algorithm being enabled there.