### PR TITLE
Update loginguard.php

### DIFF
--- a/plugins/system/loginguard/loginguard.php
+++ b/plugins/system/loginguard/loginguard.php
@@ -225,6 +225,12 @@ class PlgSystemLoginguard extends JPlugin
 		{
 			return;
 		}
+		// Joomla 3.9.0 : leave Joomla handle Privacy Rules, otherwise infinite loop
+		if ((version_compare(JVERSION, '3.8.99999', 'gt'))
+			&& (!$this->isUserConsented($user->get('id'))) )
+		{ // avoid infinite loop
+			return;
+		} 
 
 		list($isCLI, $isAdmin) = $this->isCliAdmin();
 
@@ -502,4 +508,19 @@ class PlgSystemLoginguard extends JPlugin
 		$url = 'index.php?option=com_loginguard&view=Methods';
 		$app->redirect($url, 307);
 	}
+        /* Joomla 3.9.0 : check if User Consented Privacy Rules */
+	private function isUserConsented($userId)
+	{
+            $db = JFactory::getDBo();
+		$query = $db->getQuery(true);
+		$query->select('COUNT(*)')
+			->from('#__privacy_consents')
+			->where('user_id = ' . (int) $userId)
+			->where('subject = ' . $db->quote('PLG_SYSTEM_PRIVACYCONSENT_SUBJECT'))
+			->where('state = 1');
+		$db->setQuery($query);
+
+		return (int) $db->loadResult() > 0;
+	}
+	
 }


### PR DESCRIPTION
Pull Request for Issue # .
Conflict between privacy consent system plugin and loginguard system plugin, causing an infinite loop while trying to log to frontend.

Summary of Changes
When you enable Joomla 3.9.0 privacy consent system plugin, it will try to display profile form as soon as user id is known.
At the same time, LoginGuard system plugin is looking at session parameters to decide if it needs to be launched or not. If so, it will try to force Two Step Verification form to be displayed.

Both plugins, using different information sources, are ignoring each other, causing an infinite loop.

This PR will let Privacy Consent priority as it has no way of knowing that a third party component exists.

Testing Instructions
Enable Two Step Verification on a new user.
Enable System Privacy Consent plugin.
Go to your frontend and try to log with this new usercode

Result before applying PR
Infinite loop : ERR_TOO_MANY_REDIRECTS

Result after applying PR
After logging, Profile is being displayed. After profile validation, LoginGuard form is displayed.

Backwards compatibility
Does this PR break backwards compatibility? Is it a minor break (template overrides need to be updated) or a hard b/c break (code interfacing with the public API, e.g. plugins, need to be rewritten)?

If it does break b/c document how it breaks it and what other developers making plugins or template overrides for LoginGuard should do.

Documentation Changes Required
Provide the changes which need to be done per Wiki file. Indicate which Wiki file(s) would need to be created and their proposed names.

Technical information