### PR TITLE
Update config.xml

### DIFF
--- a/component/backend/config.xml
+++ b/component/backend/config.xml
@@ -19,7 +19,7 @@
 		<field name="frontend_show_title" type="radio"
 			   default="1"
 			   label="COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_LABEL"
-			   description="COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_LDESC"
+			   description="COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_DESC"
 			   class="btn-group">
 			<option value="0">JNo</option>
 			<option value="1">JYes</option>


### PR DESCRIPTION
While making an nl-BE language pack i've encountered a "problem" on the backend. When going into component options the description label for "show title on front-end" isn't being loaded. The tooltip is looking for a string "COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_**L**DESC"

however neither the front-end nor the backend contain that string. But there is a mention of it in com_loginguard\backend\config.xml line 22

Changing the translated language file (in my case line 15) in /administrator/language/nl-BE/nl-BE.com_loginguard.sys.ini from 

`COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_DESC=`
to
`COM_LOGINGUARD_CONFIG_FRONTEND_SHOW_TITLE_LDESC=`

Properly loads the language string.

Language fix pull request created.