### PR TITLE
Fix for constant (does not match)

### DIFF
--- a/plugins/actionlog/loginguard/loginguard.php
+++ b/plugins/actionlog/loginguard/loginguard.php
@@ -230,7 +230,7 @@ class plgActionlogLoginguard extends CMSPlugin
 		$this->container->platform->logUserAction([
 			'user_id'  => $userId,
 			'otheruser' => $user->username,
-		], 'PLG_ACTIONLOG_LOGINGUARD_ACTION_METHOD_DISABLE', 'com_loginguard');
+		], 'PLG_ACTIONLOG_LOGINGUARD_ACTION_METHODS_DISABLE', 'com_loginguard');
 	}
 
 	/**


### PR DESCRIPTION
A small fix for a constant (does not match a constant in a language file).

![Screenshot_2](https://user-images.githubusercontent.com/8440661/82259925-030aaf80-9965-11ea-8ac0-6bcaa5e19724.png)
