### PR TITLE
PushBullet: change input type to "number"

### DIFF
--- a/plugins/loginguard/pushbullet/pushbullet.php
+++ b/plugins/loginguard/pushbullet/pushbullet.php
@@ -229,7 +229,7 @@ class PlgLoginguardPushbullet extends CMSPlugin
 			// How to render the TFA setup code field. "input" (HTML input element) or "custom" (custom HTML)
 			'field_type'     => 'input',
 			// The type attribute for the HTML input box. Typically "text" or "password". Use any HTML5 input type.
-			'input_type'     => 'text',
+			'input_type'     => 'number',
 			// Pre-filled value for the HTML input box. Typically used for fixed codes, the fixed YubiKey ID etc.
 			'input_value'    => '',
 			// Placeholder text for the HTML input box. Leave empty if you don't need it.
@@ -362,7 +362,7 @@ class PlgLoginguardPushbullet extends CMSPlugin
 			// How to render the TFA code field. "input" (HTML input element) or "custom" (custom HTML)
 			'field_type'   => 'input',
 			// The type attribute for the HTML input box. Typically "text" or "password". Use any HTML5 input type.
-			'input_type'   => 'text',
+			'input_type'   => 'number',
 			// Placeholder text for the HTML input box. Leave empty if you don't need it.
 			'placeholder'  => JText::_('PLG_LOGINGUARD_PUSHBULLET_LBL_SETUP_PLACEHOLDER'),
 			// Label to show above the HTML input box. Leave empty if you don't need it.


### PR DESCRIPTION
### Summary of Changes
Change the type of the `input` field to `number`. On desktop browser it will have minimal impact, while on mobile the keyboard will switch to "numbers only" for easier writing.

### Testing Instructions

* Apply the patch
* Try to login using PushBullet

### Result before applying PR
Using a _mobile_ browser, you will get the full keyboard (chars and digits)

### Result after applying PR
On _mobile_ browser, you will get a smaller keyboard with digits only.

### Backwards compatibility

Full b/c

### Documentation Changes Required

Nothing

### Translation impact

Nothing

### Technical information

Nothing interesting